### PR TITLE
fix: add missing space-mono.css file

### DIFF
--- a/serve/space-mono.css
+++ b/serve/space-mono.css
@@ -1,0 +1,31 @@
+@font-face {
+    font-family: 'Space Mono';
+    src: url('src/space-mono/SpaceMono-Regular.woff2') format('woff2'),
+        url('src/space-mono/SpaceMono-Regular.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Space Mono';
+    src: url('src/space-mono/SpaceMono-Italic.woff2') format('woff2'),
+        url('src/space-mono/SpaceMono-Italic.woff') format('woff');
+    font-weight: normal;
+    font-style: italic;
+}
+
+@font-face {
+    font-family: 'Space Mono';
+    src: url('src/space-mono/SpaceMono-BoldItalic.woff2') format('woff2'),
+        url('src/space-mono/SpaceMono-BoldItalic.woff') format('woff');
+    font-weight: bold;
+    font-style: italic;
+}
+
+@font-face {
+    font-family: 'Space Mono';
+    src: url('src/space-mono/SpaceMono-Bold.woff2') format('woff2'),
+        url('src/space-mono/SpaceMono-Bold.woff') format('woff');
+    font-weight: bold;
+    font-style: normal;
+}


### PR DESCRIPTION
Hi,

I would like to use this font, but I've noticed that `space-mono.css` file is
missing for some reason. This PR should resolve that issue.